### PR TITLE
Feature/Add sortable to Product / Parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'v2.10-penrose')
 gem 'solidus', github: 'penrosehill/solidus', branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus', github: 'penrosehill/solidus', branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -39,6 +39,18 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
     render 'spree/admin/parts/update_parts_table'
   end
 
+  def update_positions
+    ActiveRecord::Base.transaction do
+      params[:positions].each do |variant_id, index|
+        @product.assemblies_parts.find_by(part_id: variant_id).set_list_position(index)
+      end
+    end
+
+    respond_to do |format|
+      format.js { head :no_content }
+    end
+  end
+
   private
 
   def find_product

--- a/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
@@ -5,7 +5,8 @@ module SolidusProductAssembly
     module ProductDecorator
       def self.prepended(base)
         base.class_eval do
-          has_and_belongs_to_many :parts, class_name: "Spree::Variant",
+          has_and_belongs_to_many :parts, -> { order('spree_assemblies_parts.position ASC') },
+                                          class_name: "Spree::Variant",
                                           join_table: "spree_assemblies_parts",
                                           foreign_key: "assembly_id", association_foreign_key: "part_id"
 

--- a/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
@@ -9,7 +9,8 @@ module SolidusProductAssembly
                                           join_table: "spree_assemblies_parts",
                                           foreign_key: "assembly_id", association_foreign_key: "part_id"
 
-          has_many :assemblies_parts, class_name: "Spree::AssembliesPart",
+          has_many :assemblies_parts, -> { order(position: :asc) },
+                                      class_name: "Spree::AssembliesPart",
                                       foreign_key: "assembly_id"
 
           scope :individual_saled, -> { where(individual_sale: true) }

--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class AssembliesPart < ApplicationRecord
+    acts_as_list scope: :assembly
+
     belongs_to :assembly, class_name: "Spree::Product",
                           foreign_key: "assembly_id", touch: true
 

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -45,6 +45,6 @@
 <%= javascript_tag do %>
 $(document).ready(function() {
   subscribe_product_part_links();
-  Spree.refresh_sortable_tables();
+  Spree.SortableTable.refresh();
 });
 <% end if request.xhr? %>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -1,15 +1,22 @@
-<table class="index">
+<table class="index sortable" data-sortable-link="<%= update_positions_admin_product_parts_path(@product) %>">
   <thead>
   	<tr>
+      <th><!--- handle line to sort --></th>
   	  <th><%= t('spree.sku') %></th>
   		<th><%= t('spree.name') %></th>
   		<th><%= t('spree.options') %></th>
   		<th><%= t('spree.qty') %></th>
+      <th><!--- actions --></th>
   	</tr>
   </thead>
   <tbody>
     <% parts.each do |part| %>
       <tr id="<%= dom_id(part, :sel)%>">
+        <td>
+          <% if can? :update_positions, Spree::AssembliesPart %>
+            <span class="handle"></span>
+          <% end %>
+        </td>
         <td><%= part.sku %></td>
         <td><%= part.product.name %></td>
         <td><%= variant_options part %></td>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -10,7 +10,7 @@
   	</tr>
   </thead>
   <tbody>
-    <% parts.each do |part| %>
+    <% parts.each_with_index do |part, index| %>
       <tr id="<%= dom_id(part, :sel)%>">
         <td>
           <% if can? :update_positions, Spree::AssembliesPart %>
@@ -20,7 +20,7 @@
         <td><%= part.sku %></td>
         <td><%= part.product.name %></td>
         <td><%= variant_options part %></td>
-        <td><%= text_field_tag :count, @product.count_of(part) %></td>
+        <td><%= text_field_tag :count, @product.count_of(part), id: "count-#{index+1}" %></td>
   	    <td class="actions">
           <%= link_to_with_icon(
             'edit',

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -41,4 +41,10 @@
     <% end %>
   </tbody>
 </table>
-<%= javascript_tag("subscribe_product_part_links();") if request.xhr? %>
+
+<%= javascript_tag do %>
+$(document).ready(function() {
+  subscribe_product_part_links();
+  Spree.refresh_sortable_tables();
+});
+<% end if request.xhr? %>

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
-<li<%= ' class="active"' if current == "Parts" %>>
+<%= content_tag :li, class: ('active' if current == 'Parts') do %>
   <%= link_to_with_icon 'sitemap', t('spree.parts'), admin_product_parts_url(@product) %>
-</li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Spree::Core::Engine.routes.draw do
         collection do
           post :available
           get  :selected
+          post :update_positions
         end
       end
     end

--- a/db/migrate/20200826181504_add_position_to_spree_assemblies_parts.rb
+++ b/db/migrate/20200826181504_add_position_to_spree_assemblies_parts.rb
@@ -1,0 +1,5 @@
+class AddPositionToSpreeAssembliesParts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_assemblies_parts, :position, :integer
+  end
+end


### PR DESCRIPTION
Task: https://app.asana.com/0/252466457233609/1117419755453940

- I added the sortable component to `Product / Parts` tab
- I was not able to reuse the `Spree::Admin::ResourceController#update_positions` because the action receives `product_ids` and `variant_ids` but we need to update the position (*new field*) of `Spree::AssembliesPart`
- **Important:** The position of `Spree::Variant` is used for another purpose (eg. Product / Variants tab)
- Quick fix: 509ddb5cff6d472cc2b912a4a7bd0d4ec52d3b96

TODO:
 
- [x] Sortable component not working when add/edit/delete a product. I have to reload the javascript components: https://github.com/penrosehill/solidus/pull/5/commits/51fc002ffc7e709c009bc1ca5c23fcbae9fbb5ce and https://github.com/penrosehill/solidus_product_assembly/pull/2/commits/a80f049959ee1dec3c4da44b6b0e47833e54da75

---

**Update**

Contribution to the official repository: https://github.com/solidusio-contrib/solidus_product_assembly/pull/92